### PR TITLE
better github images

### DIFF
--- a/src/plugins/sources/GitHubDataSource.ts
+++ b/src/plugins/sources/GitHubDataSource.ts
@@ -36,7 +36,7 @@ export class GitHubDataSource implements ContentSource {
     this.historicalContributorUrl = config.historicalContributorUrl;
     this.githubCompany = config.githubCompany;
     this.githubRepo = config.githubRepo;
-    this.baseGithubUrl = `https://github.com/${this.githubCompany}/${this.githubRepo}/`
+    this.baseGithubUrl = `https://opengraph.githubassets.com/1/${this.githubCompany}/${this.githubRepo}/`
   }
 
   /**


### PR DESCRIPTION
Updated the baseGithubUrl assignment to use Open Graph image assets instead of the standard GitHub repository URL. This change modifies the URL format to leverage GitHub's Open Graph image service for improved link previews when sharing repository links. 