### PR TITLE
onlyGenerate flag to skip fetching from data sources and only generat…

### DIFF
--- a/src/historical.ts
+++ b/src/historical.ts
@@ -38,6 +38,7 @@ dotenv.config();
     let sourceFile = "sources.json";
     let dateStr = today.toISOString().slice(0, 10);
     let onlyFetch = false;
+    let onlyGenerate = false;
     let beforeDate;
     let afterDate;
     let duringDate;
@@ -48,6 +49,8 @@ dotenv.config();
         sourceFile = arg.split('=')[1];
       } else if (arg.startsWith('--date=')) {
         dateStr = arg.split('=')[1];
+      } else if (arg.startsWith('--onlyGenerate=')) {
+        onlyGenerate = arg.split('=')[1].toLowerCase() == 'true';
       } else if (arg.startsWith('--onlyFetch=')) {
         onlyFetch = arg.split('=')[1].toLowerCase() == 'true';
       } else if (arg.startsWith('--before=')) {
@@ -85,6 +88,9 @@ dotenv.config();
      */
     if (typeof configJSON?.settings?.onlyFetch === 'boolean') {
       onlyFetch = configJSON?.settings?.onlyFetch || onlyFetch;
+    }
+    if (typeof configJSON?.settings?.onlyGenerate === 'boolean') {
+      onlyGenerate = configJSON?.settings?.onlyGenerate || onlyGenerate;
     }
     
     /**
@@ -177,17 +183,19 @@ dotenv.config();
      * If a date range is specified, fetch data for the entire range
      * Otherwise, fetch data for the specific date
      */
-    if (filter.filterType || (filter.after && filter.before)) {
-      for (const config of sourceConfigs) {
-        await aggregator.fetchAndStoreRange(config.instance.name, filter);
+    if (!onlyGenerate) {
+      if (filter.filterType || (filter.after && filter.before)) {
+        for (const config of sourceConfigs) {
+          await aggregator.fetchAndStoreRange(config.instance.name, filter);
+        }
+      } else {
+        for (const config of sourceConfigs) {
+          await aggregator.fetchAndStore(config.instance.name, dateStr);
+        }
       }
-    } else {
-      for (const config of sourceConfigs) {
-        await aggregator.fetchAndStore(config.instance.name, dateStr);
-      }
+      console.log("Content aggregator is finished fetching historical.");
     }
     
-    console.log("Content aggregator is finished fetching historical.");
 
     /**
      * Generate summaries if not in fetch-only mode

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,15 @@ dotenv.config();
     let sourceFile = "sources.json";
     let runOnce = false;
     let onlyFetch = false;
+    let onlyGenerate = false;
     let outputPath = './'; // Default output path
     
     args.forEach(arg => {
       if (arg.startsWith('--source=')) {
         sourceFile = arg.split('=')[1];
+      }
+      if (arg.startsWith('--onlyGenerate=')) {
+        onlyGenerate = arg.split('=')[1].toLowerCase() == 'true';
       }
       if (arg.startsWith('--onlyFetch=')) {
         onlyFetch = arg.split('=')[1].toLowerCase() == 'true';
@@ -70,6 +74,9 @@ dotenv.config();
      */
     if (typeof configJSON?.settings?.runOnce === 'boolean') {
       runOnce = configJSON?.settings?.runOnce || runOnce;
+    }
+    if (typeof configJSON?.settings?.onlyGenerate === 'boolean') {
+      onlyGenerate = configJSON?.settings?.onlyGenerate || onlyGenerate;
     }
     if (typeof configJSON?.settings?.onlyFetch === 'boolean') {
       onlyFetch = configJSON?.settings?.onlyFetch || onlyFetch;
@@ -138,12 +145,14 @@ dotenv.config();
      * Set up data collection schedules for each source
      * Each source runs at its configured interval
      */
-    for (const config of sourceConfigs) {
-      await aggregator.fetchAndStore(config.instance.name);
-
-      setInterval(() => {
-        aggregator.fetchAndStore(config.instance.name);
-      }, config.interval);
+    if (!onlyGenerate) {
+      for (const config of sourceConfigs) {
+        await aggregator.fetchAndStore(config.instance.name);
+  
+        setInterval(() => {
+          aggregator.fetchAndStore(config.instance.name);
+        }, config.interval);
+      }
     }
     
     /**


### PR DESCRIPTION
## Summary

This PR introduces support for two new CLI/config flags: `--onlyGenerate`, enabling finer control over data aggregation and summarization processes. These options allow users to run only the summary generation, depending on their needs.

## Changes

### `src/historical.ts`
- Added new CLI flags:
  - `--onlyGenerate`: skips data fetching and only generates summaries
- Updated config parsing to support these new flags from `settings`
- Refactored logic to respect `onlyGenerate` during execution

### `src/index.ts`
- Added `--onlyGenerate` CLI flags
- Integrated flag handling into config parsing and aggregator control flow
- Data fetch scheduling is now conditional on `onlyGenerate` being `false`

## Motivation

These changes allow for more modular and reusable data pipeline executions, making it easier to split the fetch and generate stages in different environments or stages of a CI/CD pipeline.

## Notes

- Backward-compatible: if neither flag is provided, default behavior remains unchanged.